### PR TITLE
Remove obsolete debug option

### DIFF
--- a/infra/k8s/timescaledb.yaml
+++ b/infra/k8s/timescaledb.yaml
@@ -36,22 +36,21 @@ spec:
       labels:
         app: timescaledb
     spec:
-    #hostNework: true
-    containers:
-      - name: timescaledb
-        image: timescale/timescaledb:latest-pg14
-        ports:
-          - containerPort: 5432
-        env:
-          - name: POSTGRES_DB
-            value: stockdata
-          - name: POSTGRES_USER
-            value: admin
-          - name: POSTGRES_PASSWORD
-            value: secret
-        volumeMounts:
-          - mountPath: /var/lib/postgresql/data
-            name: timescaledb-storage
+      containers:
+        - name: timescaledb
+          image: timescale/timescaledb:latest-pg14
+          ports:
+            - containerPort: 5432
+          env:
+            - name: POSTGRES_DB
+              value: stockdata
+            - name: POSTGRES_USER
+              value: admin
+            - name: POSTGRES_PASSWORD
+              value: secret
+          volumeMounts:
+            - mountPath: /var/lib/postgresql/data
+              name: timescaledb-storage
     volumes:
       - name: timescaledb-storage
         persistentVolumeClaim:


### PR DESCRIPTION
## Summary
- delete `#hostNework: true` from TimescaleDB deployment YAML
- fix container indentation

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_685627d17cd08330a3095bfd8a28410c