### PR TITLE
Fix single-ticker handling in fetch_and_store_batch

### DIFF
--- a/app/services/put_service.py
+++ b/app/services/put_service.py
@@ -149,13 +149,19 @@ def fetch_and_store_batch(tickers, interval, start_map):
         return {}
 
     results = {}
-    for ticker in tickers:
-        if ticker in df.columns.get_level_values(1):
-            df_ticker = df.xs(ticker, axis=1, level=1)
-            results[ticker] = df_ticker
-        else:
-            logger.warning(f"⚠️ Ticker '{ticker}' not found in data columns for batch {tickers} ({interval})")
-            results[ticker] = pd.DataFrame()
+    if df.columns.nlevels == 1:
+        # yfinance omits the ticker level when only one ticker is requested
+        results[tickers[0]] = df
+    else:
+        for ticker in tickers:
+            if ticker in df.columns.get_level_values(1):
+                df_ticker = df.xs(ticker, axis=1, level=1)
+                results[ticker] = df_ticker
+            else:
+                logger.warning(
+                    f"⚠️ Ticker '{ticker}' not found in data columns for batch {tickers} ({interval})"
+                )
+                results[ticker] = pd.DataFrame()
 
     return results
 

--- a/app/tests/test_put_service.py
+++ b/app/tests/test_put_service.py
@@ -1,0 +1,78 @@
+import sys
+from pathlib import Path
+import importlib
+from datetime import datetime
+from unittest.mock import patch
+
+import pandas as pd
+
+sys.path.append(str(Path(__file__).resolve().parents[1]))
+
+def load_put_service():
+    """Import put_service with mocked config to avoid AWS calls."""
+    with patch('stocklib.config.load_config', return_value={
+        'PGHOST': '', 'PGUSER': '', 'PGPASSWORD': '', 'PGDATABASE': '', 'PGPORT': '5432', 'symbols': []
+    }):
+        if 'services.put_service' in sys.modules:
+            module = sys.modules['services.put_service']
+            return importlib.reload(module)
+        return importlib.import_module('services.put_service')
+
+
+def make_multi_index_df():
+    dates = pd.date_range("2024-01-01", periods=2)
+    columns = pd.MultiIndex.from_product([
+        ["Adj Close", "Close", "High", "Low", "Open", "Volume"],
+        ["AAPL", "MSFT"]
+    ], names=["Price", "Ticker"])
+    data = {
+        (col, tic): [1.0, 2.0] for col in [
+            "Adj Close", "Close", "High", "Low", "Open", "Volume"] for tic in ["AAPL", "MSFT"]
+    }
+    df = pd.DataFrame(data, index=dates)
+    return df
+
+
+def make_single_level_df():
+    dates = pd.date_range("2024-01-01", periods=2)
+    data = {
+        "Adj Close": [1.0, 2.0],
+        "Close": [1.0, 2.0],
+        "High": [1.0, 2.0],
+        "Low": [1.0, 2.0],
+        "Open": [1.0, 2.0],
+        "Volume": [1.0, 2.0]
+    }
+    df = pd.DataFrame(data, index=dates)
+    return df
+
+
+class TestFetchAndStoreBatch:
+    def test_single_ticker_single_level_df(self):
+        df = make_single_level_df()
+        ps = load_put_service()
+        with patch('yfinance.download', return_value=df) as mock_dl:
+            result = ps.fetch_and_store_batch(
+                ['AAPL'], '1d', {'AAPL': datetime(2024, 1, 1)}
+            )
+            mock_dl.assert_called_once()
+        pd.testing.assert_frame_equal(result['AAPL'], df)
+
+    def test_multi_ticker_multi_index_df(self):
+        df = make_multi_index_df()
+        ps = load_put_service()
+        with patch('yfinance.download', return_value=df):
+            result = ps.fetch_and_store_batch(
+                ['AAPL', 'MSFT'], '1d', {'AAPL': None, 'MSFT': None}
+            )
+        pd.testing.assert_frame_equal(result['AAPL'], df.xs('AAPL', axis=1, level=1))
+        pd.testing.assert_frame_equal(result['MSFT'], df.xs('MSFT', axis=1, level=1))
+
+    def test_missing_ticker_returns_empty_df(self):
+        df = make_multi_index_df().xs('AAPL', axis=1, level=1, drop_level=False)
+        ps = load_put_service()
+        with patch('yfinance.download', return_value=df):
+            result = ps.fetch_and_store_batch(
+                ['AAPL', 'MSFT'], '1d', {'AAPL': None, 'MSFT': None}
+            )
+        assert result['MSFT'].empty


### PR DESCRIPTION
## Summary
- ensure `fetch_and_store_batch` works with a single ticker
- clarify comment for single ticker case
- group put_service tests and mirror the service filename

## Testing
- `pip install -q -r app/requirements.txt`
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_68562c405ba4833088185b357ed2ad7d