### PR TITLE
Implement TA service framework

### DIFF
--- a/.vscode/launch.json
+++ b/.vscode/launch.json
@@ -5,11 +5,29 @@
     "version": "0.2.0",
     "configurations": [
         {
-            "name": "Python Debugger: Current File",
+            "name": "Dbg: Current File",
             "type": "debugpy",
             "request": "launch",
             "program": "${file}",
             "console": "integratedTerminal"
+        },
+        {
+            "name": "dbg: put_service",
+            "type": "debugpy",
+            "request": "launch",
+            "program": "${workspaceFolder}/app/services/put_service.py",
+            "console": "integratedTerminal"
+        },
+        {
+            "name": "dbg: ta_service",
+            "type": "debugpy",
+            "request": "launch",
+            "program": "${workspaceFolder}/app/services/ta_service.py",
+            "console": "integratedTerminal",
+            "args": [
+                "-ta_name",
+                "macd"
+            ]
         }
     ]
 }

--- a/app/services/ta_service.py
+++ b/app/services/ta_service.py
@@ -1,21 +1,38 @@
 import os
 import logging
+import json
+
 from stocklib.messaging import EventBus
 from stocklib.config import load_config
-import json
 
 logging.basicConfig(level=logging.INFO, format='%(asctime)s %(levelname)s %(message)s')
 logger = logging.getLogger(__name__)
 
 ENV = os.getenv("STOCKAPP_ENV", "devtest")
+TA_NAME = os.getenv("TA_NAME")
 config = load_config(ENV)
+
+if not TA_NAME:
+    raise ValueError("TA_NAME environment variable must be set for ta_service")
+
+symbols = config.get("symbols", [])
+logger.info(f"TA service '{TA_NAME}' starting - subscribing to {len(symbols)} pairs")
 
 bus = EventBus()
 
-for msg in bus.subscribe("stock.updated"):
+pubsub = bus.subscribe("stock.updated")
+
+for msg in pubsub.listen():
     if msg["type"] != "message":
         continue
     event = json.loads(msg["data"])
-    ticker = event["payload"]["ticker"]
-    logger.info(f"TA: Computing indicators for {ticker}")
-    bus.publish("ta.updated", "ta.updated.RSI", {"ticker": ticker, "indicator": "RSI", "value": 70})
+    ticker = event["payload"].get("ticker")
+    interval = event["payload"].get("interval")
+    logger.info(f"{TA_NAME}: analysing {ticker} ({interval})")
+    bus.publish(
+        "ta.updated",
+        f"ta.updated.{TA_NAME}",
+        {"ticker": ticker, "interval": interval, "indicator": TA_NAME, "value": 0}
+    )
+    break
+

--- a/app/services/ta_service.py
+++ b/app/services/ta_service.py
@@ -1,6 +1,7 @@
 import os
 import logging
 import json
+import argparse
 
 from stocklib.messaging import EventBus
 from stocklib.config import load_config
@@ -9,11 +10,16 @@ logging.basicConfig(level=logging.INFO, format='%(asctime)s %(levelname)s %(mess
 logger = logging.getLogger(__name__)
 
 ENV = os.getenv("STOCKAPP_ENV", "devtest")
-TA_NAME = os.getenv("TA_NAME")
+
+parser = argparse.ArgumentParser(description="Technical analysis service")
+parser.add_argument("ta_name", nargs="?", help="technical indicator name")
+args = parser.parse_args()
+
+TA_NAME = args.ta_name or os.getenv("TA_NAME")
 config = load_config(ENV)
 
 if not TA_NAME:
-    raise ValueError("TA_NAME environment variable must be set for ta_service")
+    raise ValueError("TA name must be provided via CLI argument or TA_NAME env var")
 
 symbols = config.get("symbols", [])
 logger.info(f"TA service '{TA_NAME}' starting - subscribing to {len(symbols)} pairs")

--- a/app/services/ta_service.py
+++ b/app/services/ta_service.py
@@ -6,13 +6,13 @@ import argparse
 from stocklib.messaging import EventBus
 from stocklib.config import load_config
 
-logging.basicConfig(level=logging.INFO, format='%(asctime)s %(levelname)s %(message)s')
+logging.basicConfig(level=logging.INFO, format="%(asctime)s %(levelname)s %(message)s")
 logger = logging.getLogger(__name__)
 
 ENV = os.getenv("STOCKAPP_ENV", "devtest")
 
 parser = argparse.ArgumentParser(description="Technical analysis service")
-parser.add_argument("ta_name", nargs="?", help="technical indicator name")
+parser.add_argument("-ta_name", help="technical indicator name")
 args = parser.parse_args()
 
 TA_NAME = args.ta_name or os.getenv("TA_NAME")
@@ -38,7 +38,6 @@ for msg in pubsub.listen():
     bus.publish(
         "ta.updated",
         f"ta.updated.{TA_NAME}",
-        {"ticker": ticker, "interval": interval, "indicator": TA_NAME, "value": 0}
+        {"ticker": ticker, "interval": interval, "indicator": TA_NAME, "value": 0},
     )
     break
-

--- a/app/stocklib/config.py
+++ b/app/stocklib/config.py
@@ -4,7 +4,7 @@ import json
 
 def load_config(env="devtest", prefix="/stockapp"):
     ssm = boto3.client("ssm", region_name=os.getenv("AWS_REGION", "ap-southeast-2"))
-    keys = ["PGHOST", "PGUSER", "PGPASSWORD", "PGDATABASE", "PGPORT", "symbols"]
+    keys = ["PGHOST", "PGUSER", "PGPASSWORD", "PGDATABASE", "PGPORT", "symbols", "TA"]
     result = {}
     for key in keys:
         name = f"{prefix}/{env}/{key}"

--- a/infra/init/init_ssm.py
+++ b/infra/init/init_ssm.py
@@ -8,7 +8,8 @@ DEFAULT_CONFIG = {
     "PGPASSWORD": "secret",
     "PGDATABASE": "stockdata",
     "PGPORT": "30432",
-    "symbols": [("AAPL", "1m"), ("GOOGL", "1m"), ("AMZN", "5m"),("AMZN", "1m"),("AMZN", "1h"),("ACN", "5m"),("ACN", "1m"),("ACN", "1h")]
+    "symbols": [("AAPL", "1m"), ("GOOGL", "1m"), ("AMZN", "5m"),("AMZN", "1m"),("AMZN", "1h"),("ACN", "5m"),("ACN", "1m"),("ACN", "1h")],
+    "TA": ["macd", "rsi"]
 }
 
 def put_parameters(env="devtest", prefix="/stockapp", region="ap-southeast-2"):

--- a/infra/k8s/ta_service.yaml
+++ b/infra/k8s/ta_service.yaml
@@ -1,0 +1,20 @@
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: ta-service
+spec:
+  replicas: 1
+  selector:
+    matchLabels:
+      app: ta-service
+  template:
+    metadata:
+      labels:
+        app: ta-service
+    spec:
+      containers:
+        - name: ta-service
+          image: ta-service:latest
+          env:
+            - name: TA_NAME
+              value: macd

--- a/scratch/clear rows
+++ b/scratch/clear rows
@@ -1,0 +1,17 @@
+WITH ranked_rows AS (
+    SELECT
+        ticker,
+        interval,
+        ts,
+        ROW_NUMBER() OVER (
+            PARTITION BY ticker, interval
+            ORDER BY ts DESC
+        ) AS rn
+    FROM stock_ohlcv
+)
+DELETE FROM stock_ohlcv s
+USING ranked_rows r
+WHERE s.ticker = r.ticker
+  AND s.interval = r.interval
+  AND s.ts = r.ts
+  AND r.rn <= 10;


### PR DESCRIPTION
## Summary
- support new `TA` config key
- bootstrap SSM with sample TA values
- implement `ta_service.py` that reads the `TA_NAME` environment variable
- subscribe to price updates and publish a TA update once before exiting

## Testing
- `pip install -q -r app/requirements.txt`
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_68563d5252b48330a6d975e92bb29036