### PR TITLE
Handle NaNs in MACD calculation

### DIFF
--- a/services/ta/ta_service.py
+++ b/services/ta/ta_service.py
@@ -110,6 +110,13 @@ def calculate_macd(df: pd.DataFrame) -> pd.DataFrame:
     if talib is None:
         raise ImportError("talib library is required to compute MACD")
 
+    if df["close"].isna().any():
+        nan_count = df["close"].isna().sum()
+        logger.error(f"Found {nan_count} NaN close values - skipping those rows")
+        df = df.dropna(subset=["close"]).reset_index(drop=True)
+        if df.empty:
+            return pd.DataFrame()
+
     try:
         closes = (
             pd.to_numeric(df["close"], errors="raise")


### PR DESCRIPTION
## Summary
- drop rows with NaN closes before computing MACD
- log skipped NaN rows
- test that NaN rows are logged and skipped

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_685e67bfc6d08330a2c39e1a8ad9ddab