### PR TITLE
Add tests for put microservice

### DIFF
--- a/.vscode/settings.json
+++ b/.vscode/settings.json
@@ -4,10 +4,13 @@
     ],
     "python.testing.unittestArgs": [
         "-v",
-        "-s",
-        "./app/tests",
-        "-p",
-        "test_*.py"
+        "-s", "./services/audit/tests",
+        "-s", "./services/order/tests",
+        "-s", "./services/put/tests",
+        "-s", "./services/strategy/tests",
+        "-s", "./services/ta/tests",
+        "-s", "./common/pubsub_wrapper/tests",
+        "-p", "test_*.py"
     ],
     "python.testing.pytestEnabled": false,
     "python.testing.unittestEnabled": true

--- a/.vscode/settings.json
+++ b/.vscode/settings.json
@@ -4,13 +4,10 @@
     ],
     "python.testing.unittestArgs": [
         "-v",
-        "-s", "./services/audit/tests",
-        "-s", "./services/order/tests",
-        "-s", "./services/put/tests",
-        "-s", "./services/strategy/tests",
-        "-s", "./services/ta/tests",
-        "-s", "./common/pubsub_wrapper/tests",
-        "-p", "test_*.py"
+        "-s",
+        ".",
+        "-p",
+        "test_*.py"
     ],
     "python.testing.pytestEnabled": false,
     "python.testing.unittestEnabled": true

--- a/services/put/tests/test_put_service.py
+++ b/services/put/tests/test_put_service.py
@@ -139,3 +139,133 @@ class TestInsertAndPublish(unittest.TestCase):
             with self.assertRaises(Exception):
                 ps.insert_and_publish("AAPL", "1d", make_single_level_df())
             mock_pub.assert_called_once()
+
+class TestFillMissingValues(unittest.TestCase):
+    def test_returns_input_when_empty(self):
+        ps = load_put_service()
+        empty = pd.DataFrame()
+        assert ps.fill_missing_values(empty).empty
+
+    def test_fills_nan_values(self):
+        ps = load_put_service()
+        df = pd.DataFrame({
+            'Open': [1.0, float('nan'), 3.0],
+            'High': [float('nan'), 2.0, 3.0],
+            'Low': [1.0, 2.0, float('nan')],
+            'Close': [1.0, float('nan'), 3.0],
+            'Volume': [float('nan'), 2.0, 3.0],
+        })
+        filled = ps.fill_missing_values(df)
+        assert not filled.isna().any().any()
+
+
+class TestGetLatestTimestamp(unittest.TestCase):
+    def test_fetches_latest_timestamp(self):
+        ps = load_put_service()
+        mock_conn = patch('psycopg2.connect').start()
+        self.addCleanup(patch.stopall)
+        cur = mock_conn.return_value.cursor.return_value
+        cur.fetchone.return_value = [datetime(2024, 1, 1)]
+        ts = ps.get_latest_timestamp('AAPL', '1d')
+        assert ts == datetime(2024, 1, 1)
+        cur.execute.assert_called_once()
+        cur.close.assert_called_once()
+        mock_conn.return_value.close.assert_called_once()
+
+
+class TestInsertOhlcvRecords(unittest.TestCase):
+    def test_inserts_rows_and_returns_count(self):
+        ps = load_put_service()
+        df = pd.DataFrame({'Open':[1.0],'High':[2.0],'Low':[1.5],'Close':[1.8],'Volume':[10]},
+                          index=[pd.Timestamp('2024-01-01')])
+        mock_conn = patch('psycopg2.connect').start()
+        self.addCleanup(patch.stopall)
+        cur = mock_conn.return_value.cursor.return_value
+        cur.rowcount = 1
+        inserted = ps.insert_ohlcv_records('AAPL','1d',df)
+        assert inserted == 1
+        cur.executemany.assert_called_once()
+        mock_conn.return_value.commit.assert_called_once()
+        cur.close.assert_called_once()
+        mock_conn.return_value.close.assert_called_once()
+
+
+class TestNextRunTime(unittest.TestCase):
+    def test_calculates_next_minute_interval(self):
+        ps = load_put_service()
+        now = datetime(2024,1,1,0,7,15,tzinfo=ps.timezone.utc)
+        nxt = ps.next_run_time('5m', now)
+        assert nxt == datetime(2024,1,1,0,10,30,tzinfo=ps.timezone.utc)
+
+    def test_calculates_next_hour_interval(self):
+        ps = load_put_service()
+        now = datetime(2024,1,1,10,30,0,tzinfo=ps.timezone.utc)
+        nxt = ps.next_run_time('1h', now)
+        assert nxt == datetime(2024,1,1,11,0,30,tzinfo=ps.timezone.utc)
+
+    def test_calculates_next_day_interval(self):
+        ps = load_put_service()
+        now = datetime(2024,1,1,12,0,0)
+        nxt = ps.next_run_time('1d', now)
+        assert nxt == datetime(2024,1,2,0,0,30)
+
+    def test_invalid_interval_raises(self):
+        ps = load_put_service()
+        with self.assertRaises(ValueError):
+            ps.next_run_time('5x', datetime.now(ps.timezone.utc))
+
+
+class TestSleepUntilNext(unittest.TestCase):
+    def test_sleeps_for_computed_duration(self):
+        ps = load_put_service()
+        future = datetime.now(ps.timezone.utc) + pd.Timedelta(seconds=1)
+        with patch.object(ps, 'next_run_time', return_value=future) as mock_next, \
+             patch('time.sleep') as mock_sleep:
+            ps.sleep_until_next('1d')
+            mock_next.assert_called_once()
+            assert mock_sleep.called
+
+
+class DummyExecutor:
+    def __enter__(self):
+        return self
+    def __exit__(self, exc_type, exc, tb):
+        pass
+    def submit(self, fn, *args, **kwargs):
+        result = fn(*args, **kwargs)
+        class DummyFuture:
+            def result(self_inner):
+                return result
+        return DummyFuture()
+
+
+class TestRunIntegration(unittest.TestCase):
+    def test_run_fetches_and_inserts(self):
+        ps = load_put_service()
+        ps.symbols = [('AAPL','1d'), ('MSFT','1d')]
+        data = pd.DataFrame({'Open':[1], 'High':[1], 'Low':[1], 'Close':[1], 'Volume':[1]}, index=[pd.Timestamp('2024-01-01')])
+        with patch.object(ps, 'get_latest_timestamp', return_value=None) as mock_get, \
+             patch.object(ps, 'fetch_and_store_batch', return_value={'AAPL': data, 'MSFT': data}) as mock_fetch, \
+             patch.object(ps, 'insert_and_publish') as mock_insert, \
+             patch('services.put.put_service.ThreadPoolExecutor', return_value=DummyExecutor()) as mock_exec, \
+             patch('services.put.put_service.as_completed', side_effect=lambda x: x):
+            ps.run('1d')
+            assert mock_get.call_count == 2
+            mock_fetch.assert_called_once()
+            assert mock_insert.call_count == 2
+
+
+class TestRunForever(unittest.TestCase):
+    def test_run_forever_loops(self):
+        ps = load_put_service()
+        calls = {'count':0}
+        def run_side_effect(interval):
+            calls['count'] += 1
+            if calls['count'] > 1:
+                raise KeyboardInterrupt()
+        with patch.object(ps, 'run', side_effect=run_side_effect) as mock_run, \
+             patch.object(ps, 'sleep_until_next') as mock_sleep:
+            with self.assertRaises(KeyboardInterrupt):
+                ps.run_forever('1d')
+            assert mock_run.call_count == 2
+            assert mock_sleep.call_count >= 1


### PR DESCRIPTION
## Summary
- extend put service tests to cover all functions

## Testing
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_685e822453448330b0a8eb2341745cb9