### PR TITLE
Add test coverage for TA service and config

### DIFF
--- a/common/pubsub_wrapper/tests/test_config.py
+++ b/common/pubsub_wrapper/tests/test_config.py
@@ -1,0 +1,37 @@
+import json
+from unittest.mock import MagicMock, patch
+
+from pubsub_wrapper.config import load_config
+
+
+def test_load_config_parses_values():
+    responses = {
+        '/stockapp/devtest/PGHOST': 'localhost',
+        '/stockapp/devtest/PGUSER': 'user',
+        '/stockapp/devtest/PGPASSWORD': 'pass',
+        '/stockapp/devtest/PGDATABASE': 'db',
+        '/stockapp/devtest/PGPORT': '5432',
+        '/stockapp/devtest/symbols': json.dumps([['AAPL', '1d']]),
+        '/stockapp/devtest/TA': json.dumps(['macd']),
+        '/stockapp/devtest/container_registry': 'reg',
+        '/stockapp/devtest/redis_url': 'redis://localhost:6379',
+    }
+
+    def get_parameter(Name, WithDecryption=True):
+        return {'Parameter': {'Value': responses[Name]}}
+
+    mock_ssm = MagicMock()
+    mock_ssm.get_parameter.side_effect = get_parameter
+
+    with patch('boto3.client', return_value=mock_ssm):
+        cfg = load_config('devtest', '/stockapp')
+
+    assert cfg['PGHOST'] == 'localhost'
+    assert cfg['PGUSER'] == 'user'
+    assert cfg['PGPASSWORD'] == 'pass'
+    assert cfg['PGDATABASE'] == 'db'
+    assert cfg['PGPORT'] == 5432
+    assert cfg['symbols'] == [['AAPL', '1d']]
+    assert cfg['TA'] == ['macd']
+    assert cfg['container_registry'] == 'reg'
+    assert cfg['redis_url'] == 'redis://localhost:6379'

--- a/services/ta/tests/test_ta_service.py
+++ b/services/ta/tests/test_ta_service.py
@@ -4,6 +4,7 @@ import unittest
 from unittest.mock import patch
 
 import pandas as pd
+import json
 import numpy as np
 
 
@@ -129,3 +130,77 @@ class TestTAService(unittest.TestCase):
         mock_fetch.assert_called_once()
         mock_proc.assert_called_once()
         assert rows == 3
+
+class TestTAServiceDB(unittest.TestCase):
+    def test_get_latest_ohlcv_ts(self):
+        ts = load_ta_service()
+        mock_conn = patch('psycopg2.connect').start()
+        self.addCleanup(patch.stopall)
+        cur = mock_conn.return_value.cursor.return_value
+        cur.fetchone.return_value = [pd.Timestamp('2024-01-01')]
+        result = ts.get_latest_ohlcv_ts('AAPL', '1d')
+        cur.execute.assert_called_once()
+        cur.close.assert_called_once()
+        mock_conn.return_value.close.assert_called_once()
+        assert result == pd.Timestamp('2024-01-01')
+
+    def test_fetch_all_ohlcv(self):
+        ts = load_ta_service()
+        mock_conn = patch('psycopg2.connect').start()
+        self.addCleanup(patch.stopall)
+        cur = mock_conn.return_value.cursor.return_value
+        cur.fetchall.return_value = [
+            (pd.Timestamp('2024-01-01'), 1, 2, 1.5, 1.8, 10)
+        ]
+        df = ts.fetch_all_ohlcv('AAPL', '1d')
+        assert df.shape == (1, 6)
+        assert list(df.columns) == ['ts', 'open', 'high', 'low', 'close', 'volume']
+        cur.execute.assert_called_once()
+        cur.close.assert_called_once()
+        mock_conn.return_value.close.assert_called_once()
+
+    def test_fetch_recent_ohlcv(self):
+        ts = load_ta_service()
+        mock_conn = patch('psycopg2.connect').start()
+        self.addCleanup(patch.stopall)
+        cur = mock_conn.return_value.cursor.return_value
+        cur.fetchall.return_value = [
+            (pd.Timestamp('2024-01-02'), 1, 1, 1, 1, 1),
+            (pd.Timestamp('2024-01-01'), 1, 1, 1, 1, 1)
+        ]
+        df = ts.fetch_recent_ohlcv('AAPL', '1d', limit=2)
+        assert list(df['ts']) == [pd.Timestamp('2024-01-01'), pd.Timestamp('2024-01-02')]
+        cur.execute.assert_called_once()
+        cur.close.assert_called_once()
+        mock_conn.return_value.close.assert_called_once()
+
+class TestTAServiceIntegration(unittest.TestCase):
+    def test_process_backlog_publishes_updates(self):
+        ts = load_ta_service()
+        ts.config['symbols'] = [('AAPL', '1d')]
+        with patch.object(ts.algorithm, 'get_latest_ts', return_value=None), \
+             patch.object(ts, 'get_latest_ohlcv_ts', return_value=pd.Timestamp('2024-01-01')), \
+             patch.object(ts, 'fetch_all_ohlcv', return_value=pd.DataFrame({'ts':[pd.Timestamp('2024-01-02')],
+                                                                            'open':[1],'high':[1],'low':[1],'close':[1],'volume':[1]})), \
+             patch.object(ts.algorithm, 'process', return_value=1) as mock_proc, \
+             patch.object(ts.bus, 'publish') as mock_pub:
+            ts.process_backlog()
+        mock_proc.assert_called_once()
+        mock_pub.assert_called_once()
+
+    def test_run_consumes_messages(self):
+        ts = load_ta_service()
+        message = {'type':'message', 'data': json.dumps({'payload':{'ticker':'AAPL','interval':'1d'}})}
+        class DummySub:
+            def listen(self_inner):
+                yield message
+                raise KeyboardInterrupt()
+        with patch.object(ts, 'process_backlog'), \
+             patch.object(ts.bus, 'subscribe', return_value=DummySub()) as mock_sub, \
+             patch.object(ts, 'process_ticker', return_value=1) as mock_proc, \
+             patch.object(ts.bus, 'publish') as mock_pub:
+            with self.assertRaises(KeyboardInterrupt):
+                ts.run()
+        mock_sub.assert_called_once_with('stock.updated')
+        mock_proc.assert_called_once()
+        mock_pub.assert_called_once()


### PR DESCRIPTION
## Summary
- expand `test_ta_service` with database and runtime tests
- add new tests for `pubsub_wrapper.config`

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_686138cc682883309b290d67d8a4f549